### PR TITLE
fix: configurar deploy para branch gh-pages 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,19 +1,13 @@
-name: Deploy Next.js to GitHub Pages
+name: Build and Deploy to GitHub Pages
 
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
     
     steps:
     - name: Checkout 🛎️
@@ -33,16 +27,12 @@ jobs:
       env:
         NODE_ENV: production
         
-    - name: Setup Pages ⚙️
-      uses: actions/configure-pages@v4
-      with:
-        static_site_generator: next
+    - name: Add .nojekyll file 📄
+      run: touch ./out/.nojekyll
         
-    - name: Upload artifact 📤
-      uses: actions/upload-pages-artifact@v3
+    - name: Deploy to gh-pages branch �
+      uses: peaceiris/actions-gh-pages@v3
       with:
-        path: ./out
-        
-    - name: Deploy to GitHub Pages 🚀
-      id: deployment
-      uses: actions/deploy-pages@v4
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./out
+        publish_branch: gh-pages

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "export": "next build && next export",
-    "deploy": "npm run export && gh-pages -d out",
+    "deploy": "npm run build && gh-pages -d out",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- Atualizado workflow para usar peaceiris/actions-gh-pages;
- Removido script 'export' (pois o Next.js 15 não precisa);
- Configurado deploy automático para branch gh-pages;
- Adicionado .nojekyll automaticamente no build;
- Método mais simples e confiável para GitHub Pages.